### PR TITLE
Use rustup for Rust installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ but should would well with any PaaS based on the CloudFoundry stack.
 
 ##What does this buildpack do?
 
-This buildpack downloads and installs the latest stable version of Rust
-(currently 1.9.0).
+This buildpack uses [rustup](https://www.rustup.rs) to download and install a
+Rust toolchain of your choosing.
 
-Then, it will compile your application using the `cargo` command plus whatever
-build flags you specify in your application's `manifest.yml`.
+Then, it will compile your application using the `cargo build` command plus
+whatever build flags you specify in your application's `manifest.yml`.
 
-Finally, it will specify how to start your application using the start command
-you specify in your application's `manifest.yml`.
+Finally, it will determine how to start your application using the start
+command you specify in your application's `manifest.yml`.
 
 ##How do you use this buildpack?
 
@@ -25,14 +25,22 @@ As a developer using this Rust buildpack, you need to do the following:
    Rust application
 2. In your application's `manifest.yml` you should include the following
    user defined environment variables:
-     - `CARGO_BUILD_FLAGS`: the flags passed to the `cargo` command to build your
-       application. If not defined, will default to `build --release`
+     - `RUST_TOOLCHAIN`: the version of the Rust compiler to use. Should be
+       `nightly`, `beta`, or `stable`. Defaults to `stable` if not specified
+     - `RUSTUP_VERBOSE`: tells the `rustup` installer to display verbose log
+       messages. Value can be any non-empty string. Defaults to non-verbose
+     - `RUSTUP_CUSTOM`: provide a custom set of arguments to the `rustup`
+       installer tool. **Note**: this will override `RUST_TOOLCHAIN` and
+       `RUSTUP_VERBOSE` regardless of whether they are specified
+     - `CARGO_BUILD_FLAGS`: the arguments passed to the `cargo build` command
+       to build your application. If not defined, will default to `cargo build
+       --release`
      - `START_COMMAND`. This is the command that will be used to start your
        application. If not defined, will default to the value as defined by
        `application_name` within the `VCAP_APPLICATION` environment variable
 
 For example, if the binary created by your build command is in
-'target/release/my_app', your `manifest.yml` should look something like:
+`target/release/my_app`, your `manifest.yml` should look something like:
 
 ``` yaml
 ---
@@ -41,12 +49,14 @@ applications:
   instances: 1
   memory: 512 MB
   env:
-    CARGO_BUILD_FLAGS: build -j 4 --release
+    RUST_TOOLCHAIN: beta
+    RUSTUP_VERBOSE: indeed
+    CARGO_BUILD_FLAGS: -j 4 --release
     START_COMMAND: ./target/release/my_app
 ```
 If you're not deploying with a `manifest.yml`, specifying any necessary
 environment variables on the command line (e.g. via `cf push`) should work
-as well (although I haven't tested this)
+as well (although I haven't tested this.)
 
 ##License
 

--- a/bin/compile
+++ b/bin/compile
@@ -14,82 +14,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# bin/compile <BUILD_DIR> <CACHE_DIR>
+# Let's not break everything accidentally
+set -eu
+set -o pipefail
 
-# First, make sure the directories we've been given exist
-mkdir -p "$1" "$2"
+# This script is run as 'bin/compile <BUILD_DIR> <CACHE_DIR>'
+# Make sure the BUILD_DIR exists, don't worry about the CACHE_DIR for now
+mkdir -p "$1"
 
-BUILD=$(cd "$1/" && pwd)
-CACHE=$(cd "$2/" && pwd)
-BPDIR=$(dirname $(dirname $0))
-
-# Filename and URL of our binary
-RUST_FILE="rust-1.9.0-x86_64-unknown-linux-gnu.tar.gz"
-RUST_URL="http://static.rust-lang.org/dist/$RUST_FILE"
-
-# Download directory, install directory, and Cargo cache directory
-RUST_ROOT=$CACHE/rust
-RUST_PATH=$BUILD/rust-install
-CARGO_HOME=$BUILD/.cargo
+build=$(cd "$1/" && pwd)
+bpdir=$(dirname $(dirname "$0"))
 
 # Double check that we have a Cargo.toml
-if [[ ! -f "$BUILD/Cargo.toml" ]]; then
+if [[ ! -f "$build/Cargo.toml" ]]; then
     echo "Cargo.toml is required."
     exit 1
 fi
 
-echo "Checking for Rust"
+# Get our args for rustup-init in order
+toolchain=${RUST_TOOLCHAIN:-"stable"}
+verbosity=${RUSTUP_VERBOSE:+"-v"}
+custom_args=${RUSTUP_CUSTOM:-""}
+rustup_args="${custom_args:-"${verbosity:-""} --default-toolchain $toolchain"}"
 
-if [[ -d "$CACHE/rust" ]]; then
-    echo "Using $(cat $RUST_ROOT/version)"
-else
-    rm -rf $RUST_ROOT
-    mkdir -p $RUST_ROOT
+# Install Rust toolchain
+curl https://sh.rustup.rs -sSf | sh -s -- -y ${rustup_args}
 
-    # Download the most recent, recommended version of Rust
-    echo "Downloading Rust"
-    curl -sO $RUST_URL
+# Make sure .cargo/bin is on the path
+path_to_cargo="$HOME/.cargo/bin/"
+export PATH=$path_to_cargo:$PATH
 
-    tar -C $RUST_ROOT -xzf $RUST_FILE --strip-components=1
+# Do the build
+cd "$build"
+cargo build ${CARGO_BUILD_FLAGS:-"--release"}
 
-    rm -f $RUST_FILE
-fi
-
-echo "Installing Rust"
-$RUST_ROOT/install.sh --prefix="$RUST_PATH" --disable-ldconfig
-
-# Set up the DYLD_LIBRARY_PATH and LD_LIBRARY_PATH
-# since we had to do a local Rust install
-RUST_DYLD=$RUST_PATH/lib/rustlib/x86_64-unknown-linux-gnu/lib
-if [[ -d "$RUST_DYLD" ]]; then
-    if [[ -z "$DYLD_LIBRARY_PATH" ]]; then
-        export DYLD_LIBRARY_PATH=$RUST_DYLD
-    else
-        export DYLD_LIBRARY_PATH=$RUST_DYLD:$DYLD_LIBRARY_PATH
-    fi
-fi
-
-export PATH=$RUST_PATH/bin:$PATH
-export LD_LIBRARY_PATH="/usr/local/lib:$DYLD_LIBRARY_PATH"
-
-echo "Compiling"
-
-# Get application specific build instructions from "CARGO_BUILD_FLAGS"
-# environment variable specified in the application's 'manifest.yml'
-# If the variable is unset or empty, we'll build just build using
-# `cargo build --release`
-: ${CARGO_BUILD_FLAGS:="build --release"}
-
-cd $BUILD && cargo ${CARGO_BUILD_FLAGS}
-
-# If the START_COMMAND isn't set, use the application name as specified in the
-# VCAP_APPLICATION environment variable
+# Determine a default start command
 if [[ -z "$START_COMMAND" ]]; then
-    # I don't like long lines, split what should be a one-liner into three
     APP=$(echo $VCAP_APPLICATION | tr ',' '\n' | grep "application_name")
     APP=$(echo $APP | cut -d':' -f2 | tr -d '"')
     START_COMMAND="./target/release/$APP"
 fi
 
 # Modify the bin/release script with the start command
-sed -i "s@web: EMPTY@web: $START_COMMAND@" $BPDIR/bin/release
+sed -i "s@web: EMPTY@web: $START_COMMAND@" $bpdir/bin/release


### PR DESCRIPTION
Rustup is the preferred method for installing and managing Rust
toolchains. This commit modifies the buildpack to use rustup to install
the desired version of Rust using a handful of new environment
variables.

This commit additionally cleans up some extraneous code, comments, etc.

This resolves #2 and #1 
